### PR TITLE
Repo-config.csv: Change jade to pug file type for RepoSense

### DIFF
--- a/configs/repo-config.csv
+++ b/configs/repo-config.csv
@@ -3,7 +3,7 @@ https://github.com/markbind/markbind.git,master,java;js;css;json;md;mbd;mbdf;njk
 https://github.com/markbind/vue-strap.git,master,java;js;css;json;md;py;vue;,package-lock.json,Yes,,
 https://github.com/powerpointlabs/powerpointlabs.git,dev-release,html;js;css;cs,,Yes,,
 https://github.com/powerpointlabs/PowerPointLabs-Website.git,master,html;js;css;cs;md,,Yes,,
-https://github.com/reposense/reposense.git,master,java;js;scss;json;md;py;jade;gradle,src/systemtest/resources/**,Yes,,
+https://github.com/reposense/reposense.git,master,java;js;scss;json;md;py;pug;gradle,src/systemtest/resources/**,Yes,,
 https://github.com/se-edu/addressbook-level3.git,master,java;js;css;adoc;fxml;gradle,,Yes,,
 https://github.com/se-edu/duke.git,master,java;js;css;adoc;fxml,,Yes,,
 https://github.com/se-edu/learningresources.git,master,md;mbd;,,Yes,,


### PR DESCRIPTION
RepoSense currently uses `pug` instead of `jade` files.

Contribution on the `pug` files are not detected.

Let's modify the repo-config.csv to include `pug` files.