### PR TITLE
Revert changes to vue-strap repo config

### DIFF
--- a/configs/repo-config.csv
+++ b/configs/repo-config.csv
@@ -1,6 +1,6 @@
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
 https://github.com/markbind/markbind.git,master,java;js;css;json;md;mbd;mbdf;njk;py;yml,package-lock.json;test/functional/test_site/expected/**;test/functional/test_site_algolia_plugin/expected/**;test/functional/test_site_convert/expected/**;test/functional/test_site_expressive_layout/expected/**;test/functional/test_site_special_tags/expected/**;test/functional/test_site_templates/expected/**;test/functional/test_site/expected/**;test/functional/test_site/expected/**,Yes,,
-https://github.com/markbind/vue-strap.git,master,java;js;css;json;md;py;vue;,,Yes,,
+https://github.com/markbind/vue-strap.git,master,java;js;css;json;md;py;vue;,package-lock.json,Yes,,
 https://github.com/powerpointlabs/powerpointlabs.git,dev-release,html;js;css;cs,,Yes,,
 https://github.com/powerpointlabs/PowerPointLabs-Website.git,master,html;js;css;cs;md,,Yes,,
 https://github.com/reposense/reposense.git,master,java;js;scss;json;md;py;pug;gradle;sh;yml,src/systemtest/resources/**,Yes,,


### PR DESCRIPTION
There's an unexpected change to the repo config in #14 (probably because of the CSV editor plugin of VSCode is still under preview...)
This PR is reverts that unnecessary change.